### PR TITLE
move to version 2.2.3 for compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-parent</artifactId>
-        <version>2.3.0-alpha.4-SNAPSHOT</version>
+        <version>2.2.3</version>
         <relativePath>../graylog2-server/graylog-plugin-parent</relativePath>
     </parent>
 
@@ -73,7 +73,7 @@
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
-        <graylog.version>2.3.0-alpha.4-SNAPSHOT</graylog.version>
+        <graylog.version>2.2.3</graylog.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hi,
probably you align pom parent to develop line cause you are under develop but I return to corrent 
version to compile plugins
